### PR TITLE
Update balance sheet API with CRUD

### DIFF
--- a/accounts/models/accounts.py
+++ b/accounts/models/accounts.py
@@ -15,6 +15,7 @@ Accounts and baking related models.
 ##########################################################################
 
 from django.db import models
+from django.urls import reverse
 
 from ..utils import Currency
 from ..managers import AccountTypeManager
@@ -135,6 +136,9 @@ class Account(models.Model):
 
     def get_currency_enum(self):
         return Currency(self.currency)
+
+    def get_api_url(self):
+        return reverse('api:accounts-detail', kwargs={'pk': self.pk})
 
 
 ##########################################################################

--- a/accounts/models/balance.py
+++ b/accounts/models/balance.py
@@ -77,7 +77,7 @@ class BalanceSheet(models.Model):
 
     def get_api_transactions_url(self):
         kwargs = {"sheet_date": self.date.strftime("%Y-%m-%d")}
-        return reverse("sheets-api:sheet-balances-list", kwargs=kwargs)
+        return reverse("sheets-api:sheet-transactions-list", kwargs=kwargs)
 
     def is_active(self):
         """
@@ -281,7 +281,7 @@ class Transaction(models.Model):
     def get_api_url(self):
         kwargs = {
             "pk": self.pk,
-            "sheet_date": self.date.strftime("%Y-%m-%d"),
+            "sheet_date": self.sheet.date.strftime("%Y-%m-%d"),
         }
         return reverse("sheets-api:sheet-transactions-detail", kwargs=kwargs)
 

--- a/accounts/models/balance.py
+++ b/accounts/models/balance.py
@@ -71,6 +71,14 @@ class BalanceSheet(models.Model):
         date = self.date.strftime("%Y-%m-%d")
         return reverse('api:sheets-detail', kwargs={'date': date})
 
+    def get_api_balances_url(self):
+        kwargs = {"sheet_date": self.date.strftime("%Y-%m-%d")}
+        return reverse("sheets-api:sheet-balances-list", kwargs=kwargs)
+
+    def get_api_transactions_url(self):
+        kwargs = {"sheet_date": self.date.strftime("%Y-%m-%d")}
+        return reverse("sheets-api:sheet-balances-list", kwargs=kwargs)
+
     def is_active(self):
         """
         Returns True if the date of the balance sheet is within 15 days of
@@ -135,9 +143,9 @@ class Balance(models.Model):
     def get_api_url(self):
         kwargs = {
             "pk": self.pk,
-            "sheets_date": self.date.strftime("%Y-%m-%d"),
+            "sheet_date": self.date.strftime("%Y-%m-%d"),
         }
-        return reverse("sheets-api:sheets-balances-detail", kwargs=kwargs)
+        return reverse("sheets-api:sheet-balances-detail", kwargs=kwargs)
 
     def credits(self):
         """
@@ -269,6 +277,13 @@ class Transaction(models.Model):
             tx.date = payment.next_payment_date()
 
         return tx
+
+    def get_api_url(self):
+        kwargs = {
+            "pk": self.pk,
+            "sheet_date": self.date.strftime("%Y-%m-%d"),
+        }
+        return reverse("sheets-api:sheet-transactions-detail", kwargs=kwargs)
 
     def __str__(self):
         return "Transfer ${:,} from {} to {} on {}".format(

--- a/accounts/models/payments.py
+++ b/accounts/models/payments.py
@@ -18,6 +18,7 @@ from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 
 from django.db import models
+from django.urls import reverse
 from django.core.validators import MaxValueValidator, MinValueValidator
 
 
@@ -108,6 +109,17 @@ class Payment(models.Model):
     class Meta:
         db_table = "payments"
         ordering = ("debit__name", "description")
+
+    def get_api_url(self, action=None):
+        kwargs = {'pk': self.id}
+
+        if action is None:
+            return reverse('api:payments-detail', kwargs=kwargs)
+
+        if action == "transaction":
+            return reverse('api:payments-transaction', kwargs=kwargs)
+
+        raise ValueError("unknown API action '{}'".format(action))
 
     def transactions(self):
         """

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -225,10 +225,11 @@ class BalanceSheetSummarySerializer(BalanceSheetSerializer):
 
     num_accounts = serializers.SerializerMethodField()
     num_transactions = serializers.SerializerMethodField()
+    href = serializers.SerializerMethodField()
 
     class Meta(BalanceSheetSerializer.Meta):
         fields = (
-            "url", "date", "title", "memo", 'num_accounts', 'num_transactions',
+            "url", "date", "title", "memo", 'num_accounts', 'num_transactions', 'href',
         )
 
     def get_num_accounts(self, obj):
@@ -245,6 +246,10 @@ class BalanceSheetSummarySerializer(BalanceSheetSerializer):
 
     def get_num_transactions(self, obj):
         return obj.transactions.count()
+
+    def get_href(self, obj):
+        # TODO: get a better name than page
+        return obj.get_absolute_url()
 
 
 class BalanceSheetDetailSerializer(BalanceSheetSerializer):

--- a/accounts/templates/snippets/balance_modal_js_body.html
+++ b/accounts/templates/snippets/balance_modal_js_body.html
@@ -34,7 +34,7 @@
   <table class="table table-sm" id="balance-credit-transactions">
     <% _.each(rc.credits, function( item ) { %>
       <tr class="row<% if (item.complete) { %> table-active<% } %>">
-        <td class="pl-3 col-9"><%= item.account %></td>
+        <td class="pl-3 col-9"><%= item.account.name %></td>
         <td class="pr-3 col-3"><%= rc.amountfmt(item.amount) %></td>
       </tr>
     <% }); %>
@@ -46,7 +46,7 @@
   <table class="table table-sm" id="balance-debit-transactions">
     <% _.each(rc.debits, function( item ) { %>
       <tr class="row<% if (item.complete) { %> table-active<% } %>">
-        <td class="pl-3 col-9"><%= item.account %></td>
+        <td class="pl-3 col-9"><%= item.account.name %></td>
         <td class="pr-3 col-3"><%= rc.amountfmt(item.amount) %></td>
       </tr>
     <% }); %>

--- a/accounts/templates/snippets/next_sheet.html
+++ b/accounts/templates/snippets/next_sheet.html
@@ -5,7 +5,7 @@
   Go to {{ latest.date }}
 </a>
 {% else %}
-<form action="{% url 'sheets-create' %}" method="post">
+<form class="create-sheet" action="{% url 'api:sheets-list' %}" method="post">
   <input type="hidden" id="date" name="date" value="{{ next_month|date:'Y-m-d' }}" />
   <button type="submit" class="btn btn-success btn-block">Create Sheet for {{ next_month }}</button>
   {% csrf_token %}

--- a/accounts/tests/conftest.py
+++ b/accounts/tests/conftest.py
@@ -1,0 +1,58 @@
+# account.tests.conftest
+# pytest fixtures and configuration for account tests
+#
+# Author:   Benjamin Bengfort <benjamin@bengfort.com>
+# Created:  Sun Jul 14 09:55:57 2019 -0400
+#
+# Copyright (C) 2019 Bengfort.com
+# For license information, see LICENSE.txt
+#
+# ID: conftest.py [] benjamin@bengfort.com $
+
+"""
+pytest fixtures and configuration for account tests
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+import pytest
+
+from decimal import Decimal
+
+from .factories import this_month
+from .factories import AccountFactory, CreditCardFactory, BillingAccountFactory
+from .factories import BalanceSheetFactory, BalanceFactory, TransactionFactory
+
+
+@pytest.fixture()
+def balance_sheet(db):
+    sheet = BalanceSheetFactory.create()
+
+    # Create the various accounts
+    checking = AccountFactory()
+    savings = AccountFactory(name="Performance Savings", number="111222333455")
+    mastercard = CreditCardFactory()
+    visa = CreditCardFactory(name="Mileage Visa")
+
+    # Add the initial balances
+    BalanceFactory(sheet=sheet, account=checking, beginning=Decimal("5321.56"))
+    BalanceFactory(sheet=sheet, account=savings, beginning=Decimal("46322.21"))
+    BalanceFactory(sheet=sheet, account=mastercard, beginning=Decimal("-1822.49"))
+    BalanceFactory(sheet=sheet, account=visa, beginning=Decimal("-4873.11"))
+
+    # Create the various transactions for bill paying and balancing the checkbook
+    TransactionFactory.create(sheet=sheet, date=this_month(3), credit=checking, amount=Decimal("192.22"), debit=BillingAccountFactory(name="Electricity Bill"))
+    TransactionFactory.create(sheet=sheet, date=this_month(4), credit=checking, amount=Decimal("68.97"), debit=BillingAccountFactory(name="Water Meter"))
+    TransactionFactory.create(sheet=sheet, date=this_month(5), credit=visa, amount=Decimal("208.69"), debit=BillingAccountFactory(name="Cable Internet"))
+    TransactionFactory.create(sheet=sheet, date=this_month(14), credit=visa, amount=Decimal("112.54"), debit=BillingAccountFactory(name="Mobile Phone"))
+    TransactionFactory.create(sheet=sheet, date=this_month(12), credit=mastercard, amount=Decimal("14.99"), debit=BillingAccountFactory(name="Netflix"))
+    TransactionFactory.create(sheet=sheet, date=this_month(21), credit=mastercard, amount=Decimal("38.75"), debit=BillingAccountFactory(name="Newspaper Subscription"))
+    TransactionFactory.create(sheet=sheet, date=this_month(5), credit=visa, amount=Decimal("75.11"), debit=BillingAccountFactory(name="Trash Collection"))
+    TransactionFactory.create(sheet=sheet, date=this_month(1), credit=visa, amount=Decimal("385.45"), debit=BillingAccountFactory(name="Donations"))
+    TransactionFactory.create(sheet=sheet, date=this_month(1), credit=checking, debit=visa, amount=Decimal("3712.65"))
+    TransactionFactory.create(sheet=sheet, date=this_month(1), credit=checking, debit=mastercard, amount=Decimal("1598.33"))
+    TransactionFactory.create(sheet=sheet, date=this_month(1), credit=savings, debit=checking, amount=Decimal("750.61"))
+
+    return sheet

--- a/accounts/tests/test_models/test_balance.py
+++ b/accounts/tests/test_models/test_balance.py
@@ -76,7 +76,7 @@ def test_balance_sheet_scenario():
     """
 
     # Create the balance sheet for the month
-    # TODO: make this a fixture for reuse elsewhere
+    # NOTE: this scenario also available is a fixture in tests/conftest.py
     sheet = BalanceSheetFactory()
     assert sheet.accounts.count() == 0
 

--- a/accounts/tests/test_models/test_payments.py
+++ b/accounts/tests/test_models/test_payments.py
@@ -36,6 +36,17 @@ class TestPayment(object):
     Test the Payments model
     """
 
+    def test_get_api_url(self):
+        """
+        Test get_api_url works as expectd with action
+        """
+        payment = PaymentFactory.build(id=42)
+        assert payment.get_api_url() == "/api/payments/42/"
+        assert payment.get_api_url(action="transaction") == "/api/payments/42/transaction/"
+
+        with pytest.raises(ValueError, match="unknown API action"):
+            payment.get_api_url(action="foo")
+
     def test_transactions(self):
         """
         Test that payment transactions are returned correctly

--- a/accounts/tests/test_views/__init__.py
+++ b/accounts/tests/test_views/__init__.py
@@ -1,0 +1,19 @@
+# accounts.tests.test_views
+# View tests for the accounts app
+#
+# Author:   Benjamin Bengfort <benjamin@bengfort.com>
+# Created:  Sun Jul 07 23:04:55 2019 -0500
+#
+# Copyright (C) 2019 Bengfort.com
+# For license information, see LICENSE.txt
+#
+# ID: __init__.py [] benjamin@bengfort.com $
+
+"""
+View tests for the accounts app
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+

--- a/accounts/tests/test_views/test_api.py
+++ b/accounts/tests/test_views/test_api.py
@@ -19,10 +19,17 @@ Tests for the API views in the accounts app.
 
 import pytest
 
+from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.reverse import reverse
-from ..factories import TransactionFactory
-from ..factories import AdminUserFactory, PaymentFactory
+
+from datetime import timedelta
+from ..factories import this_month
+from ..factories import BalanceSheetFactory, TransactionFactory
+from ..factories import AdminUserFactory, UserFactory, PaymentFactory
+
+from accounts.models import BalanceSheet
+
 
 # All tests in this module use the database
 pytestmark = pytest.mark.django_db
@@ -36,26 +43,157 @@ def admin_client(db):
     return client
 
 
+@pytest.fixture()
+def client(db):
+    user = UserFactory.create()
+    client = APIClient()
+    assert client.login(username=user.username, password=user.password)
+    return client
+
+
+##########################################################################
+## Test API Authentication
+##########################################################################
+
+@pytest.mark.parametrize("endpoint", [
+    "api:accounts-list", "api:sheets-list", "api:payments-list",
+    "api:returns-list", "api:cashflow-list",
+])
+def test_require_authentication(endpoint, admin_client):
+    url = reverse(endpoint)
+
+    # Admin client should already be logged in
+    rep = admin_client.get(url)
+    assert rep.status_code == status.HTTP_200_OK, "didn't allow admin user access"
+
+    # Logout admin client and try again
+    admin_client.logout()
+    rep = admin_client.get(url)
+    assert rep.status_code == status.HTTP_403_FORBIDDEN, "allowed public access"
+
+
+##########################################################################
+## Test BalanceSheet ViewSet
+##########################################################################
+
+class TestBalanceSheetViewSet(object):
+
+    def test_sheets_list(self, admin_client):
+        url = reverse("api:sheets-list")
+
+        rep = admin_client.get(url)
+        assert rep.status_code == status.HTTP_200_OK
+        assert len(rep.json()) == 0
+
+        BalanceSheetFactory.create()
+        BalanceSheetFactory.create(date=this_month() - timedelta(weeks=4))
+
+        rep = admin_client.get(url)
+        assert rep.status_code == status.HTTP_200_OK
+        assert len(rep.json()) == 2
+
+    def test_sheets_create(self, admin_client):
+        url = reverse("api:sheets-list")
+        assert BalanceSheet.objects.count() == 0
+
+        data = {'date': '2019-10-01', 'memo': 'test balancesheet', 'title': 'Test BS'}
+        rep = admin_client.post(url, data, format='json')
+        assert rep.status_code == status.HTTP_201_CREATED
+        assert BalanceSheet.objects.count() == 1
+
+        for key, val in rep.json().items():
+            if key in data:
+                assert data[key] == val
+
+    def test_sheets_create_only_date_required(self, admin_client):
+        """
+        Test date only post to sheets create endpoint (most common usage)
+        """
+        url = reverse("api:sheets-list")
+        rep = admin_client.post(url, {'date': '2019-10-01'}, format='json')
+        assert rep.status_code == status.HTTP_201_CREATED
+
+        data = rep.json()
+        assert data["date"] == '2019-10-01'
+        assert data["memo"] is None
+        assert data["title"] is not None
+        assert data["title"] != ""
+
+    def test_sheets_create_only_one_per_month(self, admin_client):
+        """
+        Ensure two sheets cannot be created for the same month
+        """
+        url = reverse("api:sheets-list")
+        data = {'date': '2019-10-01'}
+
+        # first post should be successful
+        rep = admin_client.post(url, data, format='json')
+        assert rep.status_code == status.HTTP_201_CREATED
+
+        # second post should fail
+        rep = admin_client.post(url, data, format='json')
+        assert rep.status_code == status.HTTP_400_BAD_REQUEST
+
+        # even with a different day it should fail
+        rep = admin_client.post(url, {'date': '2019-10-15'}, format='json')
+        assert rep.status_code == status.HTTP_400_BAD_REQUEST
+
+        # delete should work
+        detail_url = reverse("api:sheets-detail", kwargs={'date': '2019-10-01'})
+        rep = admin_client.delete(detail_url)
+        assert rep.status_code == status.HTTP_204_NO_CONTENT
+
+        # post should be successful after delete
+        rep = admin_client.post(url, data, format='json')
+        assert rep.status_code == status.HTTP_201_CREATED
+
+        # second post should fail
+        rep = admin_client.post(url, data, format='json')
+        assert rep.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_sheets_detail(self, admin_client, balance_sheet):
+        url = balance_sheet.get_api_url()
+
+        rep = admin_client.get(url)
+        assert rep.status_code == status.HTTP_200_OK
+
+        data = rep.json()
+        assert data["date"] == balance_sheet.date.strftime("%Y-%m-%d")
+        assert data["title"] == balance_sheet.title
+        assert data["memo"] == balance_sheet.memo
+        assert len(data["balances"]) == balance_sheet.balances.count()
+        assert len(data["transactions"]) == balance_sheet.transactions.count()
+
+    def test_sheets_update_date(self, admin_client, balance_sheet):
+        url = balance_sheet.get_api_url()
+        data = {
+            "date": balance_sheet.date + timedelta(days=2),
+            "title": balance_sheet.title, "memo": balance_sheet.memo
+        }
+
+        rep = admin_client.put(url, data, format='json')
+        assert rep.status_code == status.HTTP_200_OK
+
+    def test_sheets_update_only_one_per_month(self, admin_client, balance_sheet):
+        # Create the first balance sheet
+        url = reverse("api:sheets-list")
+        data = {'date': '2019-10-01', "title": "", "memo": ""}
+        rep = admin_client.post(url, data, format='json')
+        assert rep.status_code == status.HTTP_201_CREATED
+
+        # Attempt to update the balance sheet to the non uniuqe month
+        url = balance_sheet.get_api_url()
+        data["title"] = balance_sheet.title
+        data["memo"] = balance_sheet.memo
+        rep = admin_client.put(url, data, format='json')
+        assert rep.status_code == status.HTTP_400_BAD_REQUEST
+
+
 ##########################################################################
 ## Test Payments API View
 ####################################################d######################
 
 class TestPaymentsAPIView(object):
-
-    def test_login_required(self, admin_client):
-        """
-        Assert that a login is required to access payments API
-        """
-        url = reverse("api:payments-list")
-
-        # Admin client should already be logged in
-        rep = admin_client.get(url)
-        assert rep.status_code == 200
-
-        # Logout admin client and try again
-        admin_client.logout()
-        rep = admin_client.get(url)
-        assert rep.status_code == 403
 
     def test_actions(self, admin_client):
         """
@@ -63,12 +201,13 @@ class TestPaymentsAPIView(object):
         """
         url = reverse("api:payments-list")
         rep = admin_client.options(url)
-        assert rep.status_code == 200
+        assert rep.status_code == status.HTTP_200_OK
 
         assert rep.get('Allow') == 'GET, POST, HEAD, OPTIONS'
 
         payment = PaymentFactory.create()
         rep = admin_client.options(payment.get_api_url())
+        assert rep.status_code == status.HTTP_200_OK
 
         assert rep.get('Allow') == 'GET, PUT, PATCH, DELETE, HEAD, OPTIONS'
 
@@ -78,12 +217,14 @@ class TestPaymentsAPIView(object):
         """
         url = reverse("api:payments-list")
         rep = admin_client.get(url)
+        assert rep.status_code == status.HTTP_200_OK
         assert len(rep.json()) == 0
 
         PaymentFactory.create()
         PaymentFactory.create()
 
         rep = admin_client.get(url)
+        assert rep.status_code == status.HTTP_200_OK
         assert len(rep.json()) == 2
 
     def test_make_transaction(self, admin_client):
@@ -92,13 +233,46 @@ class TestPaymentsAPIView(object):
         """
         payment = PaymentFactory.create()
         rep = admin_client.get(payment.get_api_url(action='transaction'))
+        assert rep.status_code == status.HTTP_200_OK
+
         data = rep.json()
 
         # Get the account pk from the url (will be used as relation in API)
         for account in ('credit', 'debit'):
             url = data.pop(account)['url']
             pk = int(list(filter(None, url.split("/")))[-1])
-            data[account+"_id"] = pk
+            data[account + "_id"] = pk
 
         # Should be able to make a transactions from the response
         TransactionFactory.create(**data)
+
+
+##########################################################################
+## Test Status Endpoint
+##########################################################################
+
+def test_status_no_auth(client):
+    # Ensure client is logged out
+    client.logout()
+
+    url = reverse("api:status-list")
+    rep = client.get(url)
+    assert rep.status_code == status.HTTP_200_OK
+
+    data = rep.json()
+    assert "status" in data and data["status"] == "ok"
+    assert "version" in data
+    assert "revision" in data
+    assert "timestamp" in data
+
+
+def test_status_auth(client, admin_client):
+    url = reverse("api:status-list")
+
+    # Non Admin Users
+    rep = client.get(url)
+    assert rep.status_code == status.HTTP_200_OK
+
+    # Admin Users
+    rep = client.get(url)
+    assert rep.status_code == status.HTTP_200_OK

--- a/accounts/tests/test_views/test_api.py
+++ b/accounts/tests/test_views/test_api.py
@@ -119,6 +119,10 @@ class TestBalanceSheetViewSet(object):
         assert data["title"] is not None
         assert data["title"] != ""
 
+        # This is required for the front end to function
+        assert data["href"] is not None
+        assert data["href"] != ""
+
     def test_sheets_create_only_one_per_month(self, admin_client):
         """
         Ensure two sheets cannot be created for the same month

--- a/accounts/tests/test_views/test_api.py
+++ b/accounts/tests/test_views/test_api.py
@@ -1,0 +1,104 @@
+# accounts.tests.test_views.test_api
+# Tests for the API views in the accounts app.
+#
+# Author:   Benjamin Bengfort <benjamin@bengfort.com>
+# Created:  Sun Jul 07 23:04:09 2019 -0500
+#
+# Copyright (C) 2019 Bengfort.com
+# For license information, see LICENSE.txt
+#
+# ID: test_api.py [] benjamin@bengfort.com $
+
+"""
+Tests for the API views in the accounts app.
+"""
+
+##########################################################################
+## Imports
+##########################################################################
+
+import pytest
+
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+from ..factories import TransactionFactory
+from ..factories import AdminUserFactory, PaymentFactory
+
+# All tests in this module use the database
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def admin_client(db):
+    admin = AdminUserFactory.create()
+    client = APIClient()
+    assert client.login(username=admin.username, password=admin.password)
+    return client
+
+
+##########################################################################
+## Test Payments API View
+####################################################d######################
+
+class TestPaymentsAPIView(object):
+
+    def test_login_required(self, admin_client):
+        """
+        Assert that a login is required to access payments API
+        """
+        url = reverse("api:payments-list")
+
+        # Admin client should already be logged in
+        rep = admin_client.get(url)
+        assert rep.status_code == 200
+
+        # Logout admin client and try again
+        admin_client.logout()
+        rep = admin_client.get(url)
+        assert rep.status_code == 403
+
+    def test_actions(self, admin_client):
+        """
+        Ensure the endpoint is RESTful for payments
+        """
+        url = reverse("api:payments-list")
+        rep = admin_client.options(url)
+        assert rep.status_code == 200
+
+        assert rep.get('Allow') == 'GET, POST, HEAD, OPTIONS'
+
+        payment = PaymentFactory.create()
+        rep = admin_client.options(payment.get_api_url())
+
+        assert rep.get('Allow') == 'GET, PUT, PATCH, DELETE, HEAD, OPTIONS'
+
+    def test_list(self, admin_client):
+        """
+        Test GET payments list
+        """
+        url = reverse("api:payments-list")
+        rep = admin_client.get(url)
+        assert len(rep.json()) == 0
+
+        PaymentFactory.create()
+        PaymentFactory.create()
+
+        rep = admin_client.get(url)
+        assert len(rep.json()) == 2
+
+    def test_make_transaction(self, admin_client):
+        """
+        Test make transaction from payment detail action
+        """
+        payment = PaymentFactory.create()
+        rep = admin_client.get(payment.get_api_url(action='transaction'))
+        data = rep.json()
+
+        # Get the account pk from the url (will be used as relation in API)
+        for account in ('credit', 'debit'):
+            url = data.pop(account)['url']
+            pk = int(list(filter(None, url.split("/")))[-1])
+            data[account+"_id"] = pk
+
+        # Should be able to make a transactions from the response
+        TransactionFactory.create(**data)

--- a/accounts/views/api.py
+++ b/accounts/views/api.py
@@ -19,8 +19,8 @@ from django.db import connection
 from ..models import Account, Payment
 from ..models import BalanceSheet, Balance, Transaction
 from ..serializers import AccountSerializer
-from ..serializers import BalanceSheetShortSerializer
 from ..serializers import BalanceSheetDetailSerializer
+from ..serializers import BalanceSheetSummarySerializer
 from ..serializers import TransactionSerializer, PaymentSerializer
 from ..serializers import BalanceDetailSerializer, BalanceSummarySerializer
 
@@ -55,7 +55,7 @@ class AccountViewSet(viewsets.ReadOnlyModelViewSet):
 ## BalanceSheet Base Resource
 ##########################################################################
 
-class BalanceSheetViewSet(viewsets.ReadOnlyModelViewSet):
+class BalanceSheetViewSet(viewsets.ModelViewSet):
     """
     Most viewsets are nested under their associated balance sheet.
     """
@@ -68,8 +68,8 @@ class BalanceSheetViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Returns list or detail balance sheet serializers
         """
-        if self.action == 'list':
-            return BalanceSheetShortSerializer
+        if self.action in {'list', 'create'}:
+            return BalanceSheetSummarySerializer
         return BalanceSheetDetailSerializer
 
 

--- a/accounts/views/api.py
+++ b/accounts/views/api.py
@@ -118,9 +118,10 @@ class CashFlow(viewsets.ViewSet):
     # TODO: move this to a SQL file that can be loaded on demand
     QUERY = (
         "WITH sheet_balances AS ("
-        "	SELECT b.beginning, b.ending, s.id AS sheet_id, s.date, a.type FROM balances b "
-        "		JOIN balance_sheets s ON b.sheet_id = s.id "
+        "	SELECT b.beginning, b.ending, s.id AS sheet_id, s.date, a.type FROM balances b"
+        "		JOIN balance_sheets s ON b.sheet_id = s.id"
         "		JOIN accounts a ON b.account_id = a.id"
+        "     WHERE a.active = 't' AND a.exclude = 'f'"
         "	ORDER BY s.date DESC"
         "), cash AS ("
         "	SELECT SUM(beginning) as beginning, SUM(ending) as ending, date FROM sheet_balances WHERE type = 'Ca' GROUP BY date"

--- a/accounts/views/balance.py
+++ b/accounts/views/balance.py
@@ -25,7 +25,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 
 
 __all__ = [
-    "BalanceSheetArchives", "BalanceSheetView", "CreateBlanceSheet",
+    "BalanceSheetArchives", "BalanceSheetView",
 ]
 
 
@@ -101,10 +101,3 @@ class BalanceSheetView(LoginRequiredMixin, DetailView):
         context = super(BalanceSheetView, self).get_context_data(**kwargs)
         context['dashboard'] = 'sheets'
         return context
-
-
-class CreateBlanceSheet(LoginRequiredMixin, CreateView):
-
-    http_method_names = ['post']
-    model = BalanceSheet
-    fields = ["date"]

--- a/accounts/views/balance.py
+++ b/accounts/views/balance.py
@@ -18,7 +18,6 @@ from ..models import BalanceSheet
 
 from django.http import Http404
 from django.views.generic import DetailView
-from django.views.generic.edit import CreateView
 from django.utils.translation import gettext as _
 from django.views.generic.dates import ArchiveIndexView
 from django.contrib.auth.mixins import LoginRequiredMixin

--- a/ledger/settings/testing.py
+++ b/ledger/settings/testing.py
@@ -39,8 +39,8 @@ DATABASES['default']['TEST'] = {'NAME': 'ledger_test'}
 STATICFILES_STORAGE =  'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 ## Content without side effects
-MEDIA_ROOT         = "/tmp/ledger/media"
-STATIC_ROOT        = "/tmp/ledger/static"
+MEDIA_ROOT         = "/tmp/ledger_test/media"
+STATIC_ROOT        = "/tmp/ledger_test/static"
 
 ##########################################################################
 ## Django REST Framework

--- a/ledger/settings/testing.py
+++ b/ledger/settings/testing.py
@@ -38,7 +38,7 @@ DATABASES['default']['TEST'] = {'NAME': 'ledger_test'}
 
 STATICFILES_STORAGE =  'django.contrib.staticfiles.storage.StaticFilesStorage'
 
-## Content without? side effects
+## Content without side effects
 MEDIA_ROOT         = "/tmp/ledger/media"
 STATIC_ROOT        = "/tmp/ledger/static"
 

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -70,7 +70,6 @@ urlpatterns = [
     path('budget/', LatestBudget.as_view(), name="budget"),
     path('budget/<int:year>/', BudgetDashboard.as_view(), name="budget-detail"),
     path('sheets/', BalanceSheetArchives.as_view(), name="sheets-archive"),
-    path('sheets/new', CreateBlanceSheet.as_view(), name="sheets-create"),
     path('sheets/<int:year>-<int:month>/', BalanceSheetView.as_view(), name="sheets-detail"),
 
     # Authentication URLs

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -46,6 +46,7 @@ router = routers.DefaultRouter()
 router.register(r'status', HeartbeatViewSet, "status")
 router.register(r'sheets', BalanceSheetViewSet, "sheets")
 router.register(r'accounts', AccountViewSet, "accounts")
+router.register(r'payments', PaymentsAPIView, "payments")
 router.register(r'returns', TaxReturnViewSet, "returns")
 router.register(r'cashflow', CashFlow, "cashflow")
 

--- a/ledger/urls.py
+++ b/ledger/urls.py
@@ -51,9 +51,9 @@ router.register(r'returns', TaxReturnViewSet, "returns")
 router.register(r'cashflow', CashFlow, "cashflow")
 
 # Routes nested below sheets
-sheets_router = routers.NestedDefaultRouter(router, r'sheets', lookup='sheets')
-sheets_router.register(r'balances', BalanceViewSet, 'sheets-balances')
-sheets_router.register(r'transactions', TransactionViewSet, 'sheets-transactions')
+sheets_router = routers.NestedDefaultRouter(router, r'sheets', lookup='sheet')
+sheets_router.register(r'balances', BalanceViewSet, base_name='sheet-balances')
+sheets_router.register(r'transactions', TransactionViewSet, base_name='sheet-transactions')
 
 
 ##########################################################################

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ env =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+    ignore:No directory at.*:UserWarning
 
 flakes-ignore =
     __init__.py UnusedImport

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 bokeh==0.12.15
 Django==2.2.3
 django-rest-framework==0.1.0
-djangorestframework==3.9.3
+djangorestframework==3.10.0
 dj-database-url==0.5.0
 drf-nested-routers==0.91
 gunicorn==19.9.0

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+latest.dump

--- a/templates/site/overview.html
+++ b/templates/site/overview.html
@@ -148,6 +148,9 @@
     var GRN = "#43ac6a";
     var URL = "{% url 'api:cashflow-list' %}";
 
+    // Bind the create sheet form to its handler
+    $("form.create-sheet").submit(createBalanceSheet);
+
     // Fetch the cash-flow data to draw the chart
     $.get(URL)
       .done(function (data) {
@@ -159,13 +162,6 @@
 
 
     function cashFlowChart(data) {
-      // var colors = [GRN, RED]
-      // if (cash_total >= debt_total) {
-      //   colors.push(GRN);
-      // } else {
-      //   colors.push(RED);
-      // }
-
       var ctx = document.getElementById('cashvdebt').getContext('2d');
       var labels = _.map(_.pluck(data, "date"), fmtDate);
 
@@ -214,6 +210,40 @@
       // Don't forget to subtract 1 from the month?!
       const [year, month, day] = s.split("-")
       return new Date(year, month-1, day).toLocaleDateString("en-US", {"month": "short", "year": "numeric"});
+    }
+
+    function createBalanceSheet(e) {
+      e.preventDefault();
+      var form = $(e.target);
+
+      // Disable the submit button
+      form.find(":submit").attr("disabled", true)
+
+      // Get the data from the form and post it
+      // Note that reduce requires the empty object as a second argument
+      var data = form.serializeArray().reduce(function(obj, item) {
+        obj[item.name] = item.value;
+        return obj;
+      }, {});
+
+      console.log(data);
+
+      $.post(form.attr("action"), data)
+        .done(function (data) {
+          window.location.href = data["href"];
+        })
+        .fail(function (jqXHR, textStatus, errorThrown) {
+          console.log(textStatus, errorThrown);
+          console.log(jqXHR.responseText);
+
+          form.find(":submit")
+            .removeClass("btn-success")
+            .addClass("btn-danger")
+            .text(errorThrown);
+        });
+
+      // prevent form from submitting
+      return false;
     }
 
   });


### PR DESCRIPTION
This PR fixes #21 by adding balance sheet CRUD actions for transactions and balances. 

This PR also fixes #46 by adding `a.active = 't' and a.exclude = 'f'` to the cashflow API query.

This PR also fixes #17 by removing the `CreateBlanceSheet` view and adding API endpoints that validate that only one balance sheet can be created in a calendar month.